### PR TITLE
UNF Nearby Planet

### DIFF
--- a/forge-gui/res/cardsfolder/n/nearby_planet.txt
+++ b/forge-gui/res/cardsfolder/n/nearby_planet.txt
@@ -1,0 +1,8 @@
+Name:Nearby Planet
+ManaCost:no cost
+Types:Land
+S:Mode$ Continuous | Affected$ Card.Self | CharacteristicDefining$ True | AddType$ AllBasicLandType & AllNonBasicLandType | Description$ Rangeling (This card is every land type, including Plains, Island, Swamp, Mountain, Forest, Desert, Gate, Lair, Locus, and all those Urza’s ones.)
+K:CARDNAME enters the battlefield tapped.
+T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSac | TriggerDescription$ When CARDNAME enters the battlefield, sacrifice it unless you pay {1}.
+SVar:TrigSac:DB$ Sacrifice | UnlessCost$ 1 | UnlessPayer$ You
+Oracle:Rangeling (This card is every land type, including Plains, Island, Swamp, Mountain, Forest, Desert, Gate, Lair, Locus, and all those Urza’s ones.)\nNearby Planet enters the battlefield tapped.\nWhen Nearby Planet enters the battlefield, sacrifice it unless you pay {1}.


### PR DESCRIPTION
Attempting to add UNF's Nearby Planet using the Omo effect from M3C (and to a lesser extent Planar Nexus from MH3) as a reference.

Tested card in Forge, seems to work as intended. The typeline is messier than with the Mistform Ultimus/changeling effect for creatures (Mistform displays "(All)" whereas the Omo version spells out the types), but it is consistent with the referenced Modern Horizons cards.